### PR TITLE
Add scripts to automate a local install / conda environment for running the Jervis Bay mission

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # aquaticus-docker
 This repo hosts the docker that will be on the robots for the Aquaticus competition.
+
+## Local Installation
+To test locally, you can set up a local version.
+
+On Ubuntu, run the following to install dependencies for MOOS.
+```
+sudo apt install -y libncurses-dev subversion g++ xterm cmake libfltk1.3-dev freeglut3-dev libpng-dev libjpeg-dev libxft-dev libxinerama-dev libtiff5-dev
+```
+
+For the Python3 virtual environment, please ensure [anaconda](https://docs.anaconda.com/free/anaconda/install/index.html), [miniconda](https://docs.conda.io/projects/miniconda/en/latest/miniconda-install.html), or [mamba](https://mamba.readthedocs.io/en/latest/installation.html) is installed. Then run the following:
+```
+./scripts/local-install.sh
+```
+
+If there are issues, you can clean the partial installation with `./scripts/local-clean.sh`, fix the issues and run again.
+
+In any new terminal, you must run `source ./start-env.sh` before the software in this repository will work.

--- a/scripts/local-clean.sh
+++ b/scripts/local-clean.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# get top-level directory of repo
+THISDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+REPODIR=$(realpath $THISDIR/../)
+DEPS="$REPODIR/deps"
+
+rm -rf $DEPS

--- a/scripts/local-install.sh
+++ b/scripts/local-install.sh
@@ -60,8 +60,8 @@ ENV_NAME="$DEPS/pyquaticus/env-full"
 conda activate $ENV_NAME
 
 # set environment variables for MOOS
-conda env config vars set PATH=${PATH}:$DEPS/moos-ivp/bin:$DEPS/moos-ivp-aquaticus/bin:$DEPS/moos-ivp-rlagent/bin:$DEPS/pyquaticus/:$DEPS/scripts:$DEPS/mdo-hurt-s/moos-ivp-surveyor/bin \
-conda env config vars set IVP_BEHAVIOR_DIRS=$DEPS/moos-ivp/lib:$DEPS/moos-ivp-aquaticus/lib:$DEPS/moos-ivp-rlagent/lib \
+conda env config vars set PATH=${PATH}:$DEPS/moos-ivp/bin:$DEPS/moos-ivp-aquaticus/bin:$REPODIR/moos-ivp-rlagent/bin:$DEPS/pyquaticus/:$DEPS/scripts:$DEPS/mdo-hurt-s/moos-ivp-surveyor/bin \
+conda env config vars set IVP_BEHAVIOR_DIRS=$DEPS/moos-ivp/lib:$DEPS/moos-ivp-aquaticus/lib:$REPODIR/moos-ivp-rlagent/lib \
 conda env config vars set SCRIPTS=$REPODIR/scripts
 conda env config vars set MOOSIVP_SOURCE_TREE_BASE=$DEPS/moos-ivp/
 

--- a/scripts/local-install.sh
+++ b/scripts/local-install.sh
@@ -70,15 +70,15 @@ conda deactivate
 eval "$(conda shell.bash hook)"
 conda activate $ENV_NAME
 
-echo "########################################## Building MOOS-IvP #################################################"
+echo "########################################## Building MOOS-IvP ##################################################"
 cd ../moos-ivp
 ./build.sh
 
-echo "########################################## Building MOOS-IvP Aquaticus #################################################"
+echo "##################################### Building MOOS-IvP Aquaticus #############################################"
 cd ../moos-ivp-aquaticus
 ./build.sh
 
-echo "########################################## Building MOOS-IvP RL Agent#################################################"
+echo "###################################### Building MOOS-IvP RL Agent #############################################"
 cd ../../moos-ivp-rlagent
 ./build.sh
 cd ..

--- a/scripts/local-install.sh
+++ b/scripts/local-install.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# DISTRIBUTION STATEMENT A. Approved for public release. Distribution is unlimited.
+#
+# This material is based upon work supported by the Under Secretary of Defense for
+# Research and Engineering under Air Force Contract No. FA8702-15-D-0001. Any opinions,
+# findings, conclusions or recommendations expressed in this material are those of the
+# author(s) and do not necessarily reflect the views of the Under Secretary of Defense
+# for Research and Engineering.
+#
+# (C) 2023 Massachusetts Institute of Technology.
+#
+# The software/firmware is provided to you on an As-Is basis
+#
+# Delivered to the U.S. Government with Unlimited Rights, as defined in DFARS
+# Part 252.227-7013 or 7014 (Feb 2014). Notwithstanding any copyright notice, U.S.
+# Government rights in this work are defined by DFARS 252.227-7013 or DFARS
+# 252.227-7014 as detailed above. Use of this work other than as specifically
+# authorized by the U.S. Government may violate any copyrights that exist in this
+# work.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
+set -o errexit
+
+# get top-level directory of repo
+THISDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+REPODIR=$(realpath $THISDIR/../)
+DEPS="$REPODIR/deps"
+
+
+echo "Cloning dependencies..."
+mkdir -p $DEPS
+cd $DEPS
+svn export https://oceanai.mit.edu/svn/moos-ivp-aro/trunk/ moos-ivp
+svn export https://oceanai.mit.edu/svn/moos-ivp-aquaticus-oai/trunk/ moos-ivp-aquaticus
+git clone https://github.com/westpoint-robotics/mdo-hurt-s.git
+git clone https://github.com/mit-ll-trusted-autonomy/pyquaticus.git
+
+
+if command -v mamba &> /dev/null; then
+    CONDATYPE="mamba"
+    MAMBABIN=`which mamba`
+    MAMBA_ROOT_PREFIX=${MAMBABIN%condabin/mamba}
+    source $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
+elif command -v conda &> /dev/null; then
+    CONDATYPE="conda"
+else
+    echo "Missing conda. Please install the latest Anaconda or Miniconda"
+    exit
+fi
+echo "Creating environment using $CONDATYPE"
+
+
+echo "########################################## Install Pyquaticus #################################################"
+cd pyquaticus
+./setup-conda-env.sh full
+eval "$(conda shell.bash hook)"
+ENV_NAME="$DEPS/pyquaticus/env-full"
+conda activate $ENV_NAME
+
+# set environment variables for MOOS
+conda env config vars set PATH=${PATH}:$DEPS/moos-ivp/bin:$DEPS/moos-ivp-aquaticus/bin:$DEPS/moos-ivp-rlagent/bin:$DEPS/pyquaticus/:$DEPS/scripts:$DEPS/mdo-hurt-s/moos-ivp-surveyor/bin \
+conda env config vars set IVP_BEHAVIOR_DIRS=$DEPS/moos-ivp/lib:$DEPS/moos-ivp-aquaticus/lib:$DEPS/moos-ivp-rlagent/lib \
+conda env config vars set SCRIPTS=$REPODIR/scripts
+conda env config vars set MOOSIVP_SOURCE_TREE_BASE=$DEPS/moos-ivp/
+
+# Deactivate and reactivate for changes to take effect
+conda deactivate
+eval "$(conda shell.bash hook)"
+conda activate $ENV_NAME
+
+echo "########################################## Building MOOS-IvP #################################################"
+cd ../moos-ivp
+./build.sh
+
+echo "########################################## Building MOOS-IvP Aquaticus #################################################"
+cd ../moos-ivp-aquaticus
+./build.sh
+
+echo "########################################## Building MOOS-IvP RL Agent#################################################"
+cd ../../moos-ivp-rlagent
+./build.sh
+cd ..
+
+echo -e "
+
+############################## Setup complete ###############################
+Run 'source start-env.sh' in each new terminal before running anything.
+
+"

--- a/start-env.sh
+++ b/start-env.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+REPODIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DEPS="$REPODIR/deps"
+
+if command -v mamba &> /dev/null; then
+    CONDATYPE="mamba"
+    MAMBABIN=`which mamba`
+    MAMBA_ROOT_PREFIX=${MAMBABIN%condabin/mamba}
+    source $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
+elif command -v conda &> /dev/null; then
+    CONDATYPE="conda"
+else
+    echo "Missing conda. Please install the latest Anaconda or Miniconda"
+    exit
+fi
+echo "Using $CONDATYPE"
+
+
+eval "$(conda shell.bash hook)"
+ENV_NAME="$DEPS/pyquaticus/env-full"
+$CONDATYPE activate $ENV_NAME
+


### PR DESCRIPTION
This PR adds scripts to set everything up locally for testing.

Note: the current trunk of `moos-ivp` is not building properly on my machine. However, other people can't seem to reproduce the errors, so it might be an issue on my end only. I have a workaround for it now, but it's not a "real fix."